### PR TITLE
Add RabbitMQ MessageService For API->Bot Communication

### DIFF
--- a/EliteAPI/Controllers/Discord/UserController.cs
+++ b/EliteAPI/Controllers/Discord/UserController.cs
@@ -381,6 +381,6 @@ public class UserController : ControllerBase {
             return BadRequest("Leaderboard channel not set.");
         }
 
-        return await _guildService.SendLeaderboardPanel(guildId, channelId, lbId);
+        return await _guildService.SendLeaderboardPanel(guildId, channelId, account.Id, lbId);
     }
 }

--- a/EliteAPI/EliteAPI.csproj
+++ b/EliteAPI/EliteAPI.csproj
@@ -22,6 +22,7 @@
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0-preview.7.23408.2" />
 		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0-rc.1" />
+		<PackageReference Include="RabbitMQ.Client" Version="6.5.0" />
 		<PackageReference Include="StackExchange.Redis" Version="2.6.122" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />

--- a/EliteAPI/Models/DTOs/Outgoing/Messaging/MessageDto.cs
+++ b/EliteAPI/Models/DTOs/Outgoing/Messaging/MessageDto.cs
@@ -1,0 +1,8 @@
+﻿namespace EliteAPI.Models.DTOs.Outgoing.Messaging; 
+
+public class MessageDto {
+    public required string Name { get; init; }
+    public required string GuildId { get; init; }
+    public required string AuthorId { get; init; }
+    public required string Data { get; init; }
+}

--- a/EliteAPI/Services/GuildService/GuildService.cs
+++ b/EliteAPI/Services/GuildService/GuildService.cs
@@ -1,37 +1,22 @@
-﻿using System.Net.Http.Headers;
-using System.Text;
-using AutoMapper;
-using EliteAPI.Config.Settings;
-using EliteAPI.Data;
-using EliteAPI.Models.DTOs.Outgoing;
+﻿using EliteAPI.Models.DTOs.Outgoing;
+using EliteAPI.Models.DTOs.Outgoing.Messaging;
 using EliteAPI.Services.DiscordService;
-using Microsoft.AspNetCore.Http.HttpResults;
+using EliteAPI.Services.MessageService;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
-using StackExchange.Redis;
 
 namespace EliteAPI.Services.GuildService; 
 
 public class GuildService : IGuildService {
-    private readonly IHttpClientFactory _httpClientFactory;
     private readonly IDiscordService _discordService;
-    private readonly ILogger<GuildService> _logger;
-    
-    private readonly string _botToken;
+    private readonly IMessageService _messageService;
 
-    private const string DiscordBaseUrl = "https://discord.com/api/v10";
-
-    public GuildService(IHttpClientFactory httpClientFactory, IDiscordService discordService, ILogger<GuildService> logger)
+    public GuildService(IDiscordService discordService, IMessageService messageService)
     {
-        _httpClientFactory = httpClientFactory;
         _discordService = discordService;
-        _logger = logger;
-        
-        _botToken = Environment.GetEnvironmentVariable("DISCORD_BOT_TOKEN") 
-                    ?? throw new Exception("DISCORD_BOT_TOKEN env variable is not set.");
+        _messageService = messageService;
     }
 
-    public async Task<ActionResult> SendLeaderboardPanel(ulong guildId, string channelId, string lbId) {
+    public async Task<ActionResult> SendLeaderboardPanel(ulong guildId, string channelId, ulong authorId, string lbId) {
         var guild = await _discordService.GetGuild(guildId);
 
         if (guild is null) {
@@ -44,51 +29,21 @@ public class GuildService : IGuildService {
             return new NotFoundObjectResult("Channel not found.");
         }
         
-        var client = _httpClientFactory.CreateClient();
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bot", _botToken);
+        var message = new MessageDto {
+            Name = "leaderboardInit",
+            GuildId = guildId.ToString(),
+            AuthorId = authorId.ToString(),
+            Data = $$"""
+                 {
+                     "channelId": "{{channelId}}",
+                     "leaderboardId": "{{lbId}}"
+                 }
+            """
+        };
+        
+        _messageService.SendMessage(message);
 
-        var embed = $@"
-            {{
-                ""embeds"": [
-                    {{
-                        ""title"": ""Jacob Leaderboard"",
-                        ""description"": ""Newly created leaderboard! Awaiting setup...""
-                    }}
-                ],
-                ""components"": [
-                    {{
-                        ""type"": 1,
-                        ""components"": [
-                            {{
-                                ""type"": 2,
-                                ""label"": ""Setup"",
-                                ""style"": 2,
-                                ""custom_id"": ""LBSETUP|{lbId}""
-                            }}
-                        ]
-                    }}
-                ],
-                ""allowed_mentions"": {{
-                    ""parse"": []
-                }}
-            }}
-        ";
-
-        try {
-            var response = await client.PostAsync($"{DiscordBaseUrl}/channels/{channelId}/messages",
-                new StringContent(embed, Encoding.UTF8, "application/json"));
-
-            if (!response.IsSuccessStatusCode) {
-                _logger.LogError("Failed to send discord message to {Guild}, {Channel}: {Reason}", guildId, channelId, response.ReasonPhrase);
-                return new UnauthorizedObjectResult("Failed to send message in Discord, check permissions.");
-            }
-
-            return new OkResult();
-        }
-        catch (Exception e) {
-            _logger.LogError("Failed to send discord message to {Guild}, {Channel}: {Reason}", guildId, channelId, e.StackTrace);
-            return new UnauthorizedObjectResult("Failed to send message in Discord, check permissions.");
-        }
+        return new OkResult();
     }
 
     public bool HasGuildAdminPermissions(UserGuildDto guild) {

--- a/EliteAPI/Services/GuildService/IGuildService.cs
+++ b/EliteAPI/Services/GuildService/IGuildService.cs
@@ -4,6 +4,6 @@ using Microsoft.AspNetCore.Mvc;
 namespace EliteAPI.Services.GuildService; 
 
 public interface IGuildService {
-    Task<ActionResult> SendLeaderboardPanel(ulong guildId, string channelId, string lbId);
+    Task<ActionResult> SendLeaderboardPanel(ulong guildId, string channelId, ulong authorId, string lbId);
     bool HasGuildAdminPermissions(UserGuildDto guild);
 }

--- a/EliteAPI/Services/MessageService/IMessageService.cs
+++ b/EliteAPI/Services/MessageService/IMessageService.cs
@@ -1,0 +1,7 @@
+﻿using EliteAPI.Models.DTOs.Outgoing.Messaging;
+
+namespace EliteAPI.Services.MessageService; 
+
+public interface IMessageService {
+    void SendMessage(MessageDto messageDto);
+}

--- a/EliteAPI/Services/MessageService/MessageService.cs
+++ b/EliteAPI/Services/MessageService/MessageService.cs
@@ -1,0 +1,46 @@
+﻿using System.Text;
+using System.Text.Json;
+using EliteAPI.Models.DTOs.Outgoing.Messaging;
+using RabbitMQ.Client;
+
+namespace EliteAPI.Services.MessageService; 
+
+public class MessageService : IMessageService {
+
+    private const string ExchangeName = "eliteapi";
+    private readonly IConnection? _connection;
+    private readonly IModel? _channel;
+    
+    public MessageService() {
+        var factory = new ConnectionFactory {
+            HostName = "localhost",
+            UserName = "user",
+            Password = "rabbitPassword123"
+        };
+
+        try {
+            _connection = factory.CreateConnection();
+            _channel = _connection.CreateModel();
+        } catch (Exception e) {
+            Console.Error.WriteLine(e);
+        }
+        
+        _channel?.ExchangeDeclare(ExchangeName, ExchangeType.Fanout);
+    }
+
+    ~MessageService() {
+        _channel?.Close();
+        _connection?.Close();
+    }
+
+    public void SendMessage(MessageDto messageDto) {
+        if (_channel is null || !_channel.IsOpen) return;
+        
+        var message = JsonSerializer.Serialize(messageDto, new JsonSerializerOptions {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+        });
+        var body = Encoding.UTF8.GetBytes(message);
+        
+        _channel.BasicPublish(ExchangeName, string.Empty, null, body);
+    }
+}

--- a/EliteAPI/Services/ServiceExtensions.cs
+++ b/EliteAPI/Services/ServiceExtensions.cs
@@ -13,6 +13,7 @@ using EliteAPI.Services.GuildService;
 using EliteAPI.Services.HypixelService;
 using EliteAPI.Services.LeaderboardService;
 using EliteAPI.Services.MemberService;
+using EliteAPI.Services.MessageService;
 using EliteAPI.Services.MojangService;
 using EliteAPI.Services.ProfileService;
 using EliteAPI.Services.TimescaleService;
@@ -31,6 +32,7 @@ public static class ServiceExtensions
         // Add services to the container.
         services.AddSingleton<HypixelRequestLimiter>();
         services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+        services.AddSingleton<IMessageService, MessageService.MessageService>();
 
         services.AddHttpClient(HypixelService.HypixelService.HttpClientName, client => {
             client.DefaultRequestHeaders.UserAgent.ParseAdd("EliteAPI");


### PR DESCRIPTION
This makes sending events to the bot/interacting with discord through the API/Website way easier. The only downside for now is that messages aren't acknowledged, which prevents error reporting to the user. This can be added in later updates, though.