### PR TITLE
Add endpoints for contest graphs

### DIFF
--- a/EliteAPI/Controllers/Contests/ContestsController.cs
+++ b/EliteAPI/Controllers/Contests/ContestsController.cs
@@ -6,6 +6,7 @@ using AutoMapper;
 using EliteAPI.Data;
 using EliteAPI.Models.DTOs.Outgoing;
 using EliteAPI.Models.Entities.Hypixel;
+using EliteAPI.Parsers.Profiles;
 using EliteAPI.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -249,8 +250,10 @@ public class ContestsController : ControllerBase
             var crop = FormatUtils.GetFormattedCropName(contest.Crop);
 
             var stripped = _mapper.Map<List<StrippedContestParticipationDto>>(participations);
-           
-            data.First(d => d.Crop.Equals(crop)).Participations = stripped;
+
+            var contestDto = data.First(d => d.Crop.Equals(crop));
+            contestDto.Participations = stripped;
+            contestDto.CalculateBrackets();
         }
 
         return Ok(data);

--- a/EliteAPI/Controllers/Contests/ContestsController.cs
+++ b/EliteAPI/Controllers/Contests/ContestsController.cs
@@ -252,6 +252,7 @@ public class ContestsController : ControllerBase
             var stripped = _mapper.Map<List<StrippedContestParticipationDto>>(participations);
 
             var contestDto = data.First(d => d.Crop.Equals(crop));
+
             contestDto.Participations = stripped;
             contestDto.CalculateBrackets();
         }

--- a/EliteAPI/Controllers/Contests/MedalGraphsController.cs
+++ b/EliteAPI/Controllers/Contests/MedalGraphsController.cs
@@ -1,0 +1,44 @@
+﻿using EliteAPI.Data;
+using EliteAPI.Models.DTOs.Outgoing;
+using EliteAPI.Utilities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace EliteAPI.Controllers.Contests; 
+
+[Route("/Graph/Medals")]
+[ApiController]
+public class MedalGraphsController(DataContext context) : ControllerBase {
+    
+    [HttpGet]
+    [ResponseCache(Duration = 60 * 60, Location = ResponseCacheLocation.Any)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(string))]
+    public async Task<ActionResult<List<CropCollectionsDataPointDto>>> GetCropCollections(int startYear, [FromQuery] int years = 1) {
+        switch (years) {
+            case < 1:
+                return BadRequest("Can't have less than 1 year of records.");
+            case > 10:
+                return BadRequest("Time range cannot be greater than 10 skyblock years.");
+        }
+
+        var start = new SkyblockDate(startYear - years - 1, 0, 0).UnixSeconds;
+        var end = new SkyblockDate(startYear - 1, 0, 0).UnixSeconds;
+
+        var profile = await context.ContestParticipations.AsNoTracking()
+            .Where(c => c.JacobContestId >= start && c.JacobContestId <= end)
+            .GroupBy(c => new { c.JacobContestId, c.MedalEarned })
+            .Select(c => new {
+                Contest = c.Key.JacobContestId,
+                Medal = c.Key.MedalEarned,
+                Lowest = c.First().Collected
+            }).GroupBy(c => c.Contest)
+            .ToListAsync();
+        //
+        // var cropCollections = await _timescaleService.GetCropCollections(profile, start, end);
+        //
+        return Ok(profile);
+    }
+    
+}

--- a/EliteAPI/Controllers/Contests/MedalGraphsController.cs
+++ b/EliteAPI/Controllers/Contests/MedalGraphsController.cs
@@ -1,5 +1,8 @@
-﻿using EliteAPI.Data;
+﻿using System.Text.Json;
+using EliteAPI.Data;
 using EliteAPI.Models.DTOs.Outgoing;
+using EliteAPI.Models.Entities.Hypixel;
+using EliteAPI.Parsers.Farming;
 using EliteAPI.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -9,36 +12,129 @@ namespace EliteAPI.Controllers.Contests;
 [Route("/Graph/Medals")]
 [ApiController]
 public class MedalGraphsController(DataContext context) : ControllerBase {
-    
-    [HttpGet]
+    private static readonly JsonSerializerOptions Options = new() {
+        PropertyNameCaseInsensitive = true
+    };
+
+    [HttpGet("now")]
     [ResponseCache(Duration = 60 * 60, Location = ResponseCacheLocation.Any)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
     [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(string))]
-    public async Task<ActionResult<List<CropCollectionsDataPointDto>>> GetCropCollections(int startYear, [FromQuery] int years = 1) {
-        switch (years) {
+    public async Task<ActionResult<ContestBracketsDetailsDto>> GetMedalBrackets([FromQuery] int months = 2) {
+        switch (months) {
             case < 1:
-                return BadRequest("Can't have less than 1 year of records.");
-            case > 10:
-                return BadRequest("Time range cannot be greater than 10 skyblock years.");
+                return BadRequest("Months cannot be less than 1.");
+            case > 12:
+                return BadRequest("Months cannot be greater than 12.");
         }
 
-        var start = new SkyblockDate(startYear - years - 1, 0, 0).UnixSeconds;
-        var end = new SkyblockDate(startYear - 1, 0, 0).UnixSeconds;
+        var end = SkyblockDate.Now;
+        var start = new SkyblockDate(end.Year - 1, end.Month - months, end.Day).UnixSeconds;
+        
+        var brackets = await GetAverageMedalBrackets(context, start, end.UnixSeconds);
 
-        var profile = await context.ContestParticipations.AsNoTracking()
-            .Where(c => c.JacobContestId >= start && c.JacobContestId <= end)
-            .GroupBy(c => new { c.JacobContestId, c.MedalEarned })
-            .Select(c => new {
-                Contest = c.Key.JacobContestId,
-                Medal = c.Key.MedalEarned,
-                Lowest = c.First().Collected
-            }).GroupBy(c => c.Contest)
-            .ToListAsync();
-        //
-        // var cropCollections = await _timescaleService.GetCropCollections(profile, start, end);
-        //
-        return Ok(profile);
+        return Ok(new ContestBracketsDetailsDto {
+            Start = start.ToString(),
+            End = end.UnixSeconds.ToString(),
+            Brackets = brackets ?? new Dictionary<string, ContestBracketsDto>()
+        });
     }
     
+    [HttpGet("{sbYear:int}/{sbMonth:int}")]
+    [ResponseCache(Duration = 60 * 60, Location = ResponseCacheLocation.Any)]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(string))]
+    public async Task<ActionResult<ContestBracketsDetailsDto>> GetMedalBrackets(int sbYear, int sbMonth, [FromQuery] int months = 2) {
+        if (sbYear < 1) {
+            return BadRequest("Year cannot be less than 1.");
+        }
+        
+        switch (sbMonth) {
+            case < 1:
+                return BadRequest("Month cannot be less than 1.");
+            case > 12:
+                return BadRequest("Month cannot be greater than 12.");
+        }
+
+        switch (months) {
+            case < 1:
+                return BadRequest("Months cannot be less than 1.");
+            case > 12:
+                return BadRequest("Months cannot be greater than 12.");
+        }
+
+        var start = new SkyblockDate(sbYear - 1, sbMonth - months, 0).UnixSeconds;
+        var end = new SkyblockDate(sbYear - 1, sbMonth, 0).UnixSeconds;
+        
+        var brackets = await GetAverageMedalBrackets(context, start, end);
+
+        return Ok(new ContestBracketsDetailsDto {
+            Start = start.ToString(),
+            End = end.ToString(),
+            Brackets = brackets ?? new(),
+        });
+    }
+
+    private static async Task<Dictionary<string, ContestBracketsDto>?> GetAverageMedalBrackets(DbContext context, long start, long end) {
+        var medals = await context.Database
+            .SqlQuery<string>($@"
+                SELECT json_agg(c) AS ""Value""
+                FROM (
+                   WITH brackets AS (
+                       SELECT
+                           ""JacobContestId"" AS contest_id,
+                           ""JacobContestId"" % 10 AS crop,
+                           MIN(""Collected"") filter (where ""MedalEarned"" = 5) AS diamond,
+                           MIN(""Collected"") filter (where ""MedalEarned"" = 4) AS platinum,
+                           MIN(""Collected"") filter (where ""MedalEarned"" = 3) AS gold,
+                           MIN(""Collected"") filter (where ""MedalEarned"" = 2) AS silver,
+                           MIN(""Collected"") filter (where ""MedalEarned"" = 1) AS bronze
+                       FROM ""ContestParticipations""
+                       WHERE ""MedalEarned"" > 0
+                       GROUP BY ""JacobContestId""
+                   )
+                   SELECT
+                       crop,
+                       AVG(diamond) as diamond,
+                       AVG(platinum) as platinum,
+                       AVG(gold) as gold,
+                       AVG(silver) as silver,
+                       AVG(bronze) as bronze
+                   FROM brackets
+                   WHERE contest_id >= {start} AND contest_id <= {end}
+                   GROUP BY crop
+                ) c
+            ")
+            .ToListAsync();
+
+        try {
+            var parsed = JsonSerializer.Deserialize<List<MedalCutoffsDbDto>>(medals.First(), Options);
+
+            var dto = parsed!.ToDictionary(
+                m => ((Crop)m.Crop).SimpleName(),
+                m => new ContestBracketsDto {
+                    Diamond = (int) (m.Diamond ?? 0),
+                    Platinum = (int) (m.Platinum ?? 0),
+                    Gold = (int) (m.Gold ?? 0),
+                    Silver = (int) (m.Silver ?? 0),
+                    Bronze = (int) (m.Bronze ?? 0)
+                });
+            
+            // Add missing crops to the dictionary
+            if (dto.Count < 9) {
+                foreach (var crop in Enum.GetValues<Crop>()) {
+                    var name = crop.SimpleName();
+                    dto.TryAdd(name, new ContestBracketsDto());
+                }
+            }
+            
+            return dto!;
+        }
+        catch 
+        {
+            return null;
+        }
+    }
 }

--- a/EliteAPI/Controllers/Contests/MedalGraphsController.cs
+++ b/EliteAPI/Controllers/Contests/MedalGraphsController.cs
@@ -17,7 +17,7 @@ public class MedalGraphsController(DataContext context) : ControllerBase {
     };
 
     [HttpGet("now")]
-    [ResponseCache(Duration = 60 * 60, Location = ResponseCacheLocation.Any)]
+    [ResponseCache(Duration = 60, Location = ResponseCacheLocation.Any)]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(string))]
     public async Task<ActionResult<ContestBracketsDetailsDto>> GetMedalBrackets([FromQuery] int months = 2) {

--- a/EliteAPI/Models/DTOs/Outgoing/Farming.cs
+++ b/EliteAPI/Models/DTOs/Outgoing/Farming.cs
@@ -54,6 +54,7 @@ public class JacobContestWithParticipationsDto
     public required string Crop { get; set; }
     public long Timestamp { get; set; }
     public int Participants { get; set; }
+    public ContestBracketsDto Brackets { get; set; } = new();
     public List<StrippedContestParticipationDto> Participations { get; set; } = new();
 }
 
@@ -63,6 +64,14 @@ public class StrippedContestParticipationDto {
     public string? Medal { get; set; }
     public string PlayerUuid { get; set; } = "";
     public string PlayerName { get; set; } = "";
+}
+
+public class ContestBracketsDto {
+    public int Bronze { get; set; } = -1;
+    public int Silver { get; set; } = -1;
+    public int Gold { get; set; } = -1;
+    public int Platinum { get; set; } = -1;
+    public int Diamond { get; set; } = -1;
 }
 
 public class ContestParticipationDto

--- a/EliteAPI/Models/DTOs/Outgoing/Farming.cs
+++ b/EliteAPI/Models/DTOs/Outgoing/Farming.cs
@@ -66,12 +66,18 @@ public class StrippedContestParticipationDto {
     public string PlayerName { get; set; } = "";
 }
 
+public class ContestBracketsDetailsDto {
+    public string Start { get; set; } = "";
+    public string End { get; set; } = "";
+    public Dictionary<string, ContestBracketsDto> Brackets { get; set; } = new();
+}
+
 public class ContestBracketsDto {
-    public int Bronze { get; set; } = -1;
-    public int Silver { get; set; } = -1;
-    public int Gold { get; set; } = -1;
-    public int Platinum { get; set; } = -1;
-    public int Diamond { get; set; } = -1;
+    public int Bronze { get; set; }
+    public int Silver { get; set; }
+    public int Gold { get; set; }
+    public int Platinum { get; set; }
+    public int Diamond { get; set; }
 }
 
 public class ContestParticipationDto
@@ -82,4 +88,13 @@ public class ContestParticipationDto
     public int Position { get; set; } = -1;
     public int Participants { get; set; } = 0;
     public string? Medal { get; set; }
+}
+
+public class MedalCutoffsDbDto {
+    public int Crop { get; set; } = -1;
+    public double? Bronze { get; set; } = -1;
+    public double? Silver { get; set; } = -1;
+    public double? Gold { get; set; } = -1;
+    public double? Platinum { get; set; } = -1;
+    public double? Diamond { get; set; } = -1;
 }

--- a/EliteAPI/Parsers/Profiles/JacobContestParser.cs
+++ b/EliteAPI/Parsers/Profiles/JacobContestParser.cs
@@ -181,14 +181,14 @@ public static class JacobContestParser
             .GroupBy(p => p.Medal)
             .Select(p => new {
                 Medal = p.Key!,
-                Collected = p.First().Collected
+                p.First().Collected
             }).ToFrozenDictionary(p => p.Medal, p => p.Collected);
         
-        brackets.Bronze = grouped.TryGetValue(ContestMedal.Bronze.MedalName(), out var bronze) ? bronze : 0;
-        brackets.Silver = grouped.TryGetValue(ContestMedal.Silver.MedalName(), out var silver) ? silver : 0;
-        brackets.Gold = grouped.TryGetValue(ContestMedal.Gold.MedalName(), out var gold) ? gold : 0;
-        brackets.Platinum = grouped.TryGetValue(ContestMedal.Platinum.MedalName(), out var platinum) ? platinum : 0;
-        brackets.Diamond = grouped.TryGetValue(ContestMedal.Diamond.MedalName(), out var diamond) ? diamond : 0;
+        brackets.Bronze = grouped.TryGetValue(ContestMedal.Bronze.MedalName(), out var bronze) ? bronze : -1;
+        brackets.Silver = grouped.TryGetValue(ContestMedal.Silver.MedalName(), out var silver) ? silver : -1;
+        brackets.Gold = grouped.TryGetValue(ContestMedal.Gold.MedalName(), out var gold) ? gold : -1;
+        brackets.Platinum = grouped.TryGetValue(ContestMedal.Platinum.MedalName(), out var platinum) ? platinum : -1;
+        brackets.Diamond = grouped.TryGetValue(ContestMedal.Diamond.MedalName(), out var diamond) ? diamond : -1;
     }
 
     private static string MedalName(this ContestMedal medal) => medal switch {


### PR DESCRIPTION
# New endpoints

- `/graph/medals/now` Medal bracket averages for current SkyBlock month
	- Query param `months` for look behind amount of months for averages
- `/graph/medals/{year}` Medal bracket averages for each month in the included years
	- Query param `months` (same as above)
	- Query param `years` for amount of years to include before the provided year
- `/graph/medals/{year}/{month}` Medal bracket averages for specific SkyBlock month
	- Query param `months` (same as above)

## Updated endpoints
- `/contests/{timestamp}`
	- Added `brackets` field 