### PR TITLE
Add Medal Bracket Columns

### DIFF
--- a/EliteAPI/Data/Migrations/20231201015427_AddMedalBracketColumns.Designer.cs
+++ b/EliteAPI/Data/Migrations/20231201015427_AddMedalBracketColumns.Designer.cs
@@ -9,6 +9,7 @@ using EliteAPI.Models.Entities.Farming;
 using EliteAPI.Models.Entities.Hypixel;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -17,9 +18,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EliteAPI.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20231201015427_AddMedalBracketColumns")]
+    partial class AddMedalBracketColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EliteAPI/Data/Migrations/20231201015427_AddMedalBracketColumns.cs
+++ b/EliteAPI/Data/Migrations/20231201015427_AddMedalBracketColumns.cs
@@ -1,0 +1,235 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EliteAPI.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMedalBracketColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "AccountId",
+                table: "MinecraftAccounts",
+                type: "numeric(20,0)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20)",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Bronze",
+                table: "JacobContests",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Diamond",
+                table: "JacobContests",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Gold",
+                table: "JacobContests",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Platinum",
+                table: "JacobContests",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Silver",
+                table: "JacobContests",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "BotPermissions",
+                table: "Guilds",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "AdminRole",
+                table: "Guilds",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Id",
+                table: "Guilds",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "OwnerId",
+                table: "Events",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "GuildId",
+                table: "Events",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Id",
+                table: "Events",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "UserId",
+                table: "EventMembers",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "EventId",
+                table: "EventMembers",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Id",
+                table: "Accounts",
+                type: "numeric(20,0)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Bronze",
+                table: "JacobContests");
+
+            migrationBuilder.DropColumn(
+                name: "Diamond",
+                table: "JacobContests");
+
+            migrationBuilder.DropColumn(
+                name: "Gold",
+                table: "JacobContests");
+
+            migrationBuilder.DropColumn(
+                name: "Platinum",
+                table: "JacobContests");
+
+            migrationBuilder.DropColumn(
+                name: "Silver",
+                table: "JacobContests");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "AccountId",
+                table: "MinecraftAccounts",
+                type: "numeric(20)",
+                nullable: true,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "BotPermissions",
+                table: "Guilds",
+                type: "numeric(20)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "AdminRole",
+                table: "Guilds",
+                type: "numeric(20)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Id",
+                table: "Guilds",
+                type: "numeric(20)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "OwnerId",
+                table: "Events",
+                type: "numeric(20)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "GuildId",
+                table: "Events",
+                type: "numeric(20)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Id",
+                table: "Events",
+                type: "numeric(20)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "UserId",
+                table: "EventMembers",
+                type: "numeric(20)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "EventId",
+                table: "EventMembers",
+                type: "numeric(20)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Id",
+                table: "Accounts",
+                type: "numeric(20)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "numeric(20,0)");
+        }
+    }
+}

--- a/EliteAPI/Models/Entities/Hypixel/Farming.cs
+++ b/EliteAPI/Models/Entities/Hypixel/Farming.cs
@@ -66,6 +66,12 @@ public class JacobContest
     public Crop Crop { get; set; }
     public long Timestamp { get; set; }
     public int Participants { get; set; }
+    
+    public int Bronze { get; set; }
+    public int Silver { get; set; }
+    public int Gold { get; set; }
+    public int Platinum { get; set; }
+    public int Diamond { get; set; }
 }
 
 public class ContestParticipation

--- a/EliteAPI/Parsers/Profiles/JacobContestParser.cs
+++ b/EliteAPI/Parsers/Profiles/JacobContestParser.cs
@@ -104,11 +104,14 @@ public static class JacobContestParser
                     JacobContestId = actualKey
                 };
                 
+                fetched.UpdateMedalBracket(newParticipation);
                 newParticipations.Add(newParticipation);
             } else {
                 existing.Collected = contest.Collected;
                 existing.Position = contest.Position ?? -1;
                 existing.MedalEarned = medal;
+                
+                fetched.UpdateMedalBracket(existing);
             }
         }
 
@@ -189,6 +192,38 @@ public static class JacobContestParser
         brackets.Gold = grouped.TryGetValue(ContestMedal.Gold.MedalName(), out var gold) ? gold : -1;
         brackets.Platinum = grouped.TryGetValue(ContestMedal.Platinum.MedalName(), out var platinum) ? platinum : -1;
         brackets.Diamond = grouped.TryGetValue(ContestMedal.Diamond.MedalName(), out var diamond) ? diamond : -1;
+    }
+
+    private static void UpdateMedalBracket(this JacobContest contest, ContestParticipation participation) {
+        if (participation.MedalEarned == ContestMedal.None) return;
+
+        switch (participation.MedalEarned) {
+            case ContestMedal.Bronze:
+                if (contest.Bronze == 0 || contest.Bronze > participation.Collected) {
+                    contest.Bronze = participation.Collected;
+                }
+                break;
+            case ContestMedal.Silver:
+                if (contest.Silver == 0 || contest.Silver > participation.Collected) {
+                    contest.Silver = participation.Collected;
+                }
+                break;
+            case ContestMedal.Gold:
+                if (contest.Gold == 0 || contest.Gold > participation.Collected) {
+                    contest.Gold = participation.Collected;
+                }
+                break;
+            case ContestMedal.Platinum:
+                if (contest.Platinum == 0 || contest.Platinum > participation.Collected) {
+                    contest.Platinum = participation.Collected;
+                }
+                break;
+            case ContestMedal.Diamond:
+                if (contest.Diamond == 0 || contest.Diamond > participation.Collected) {
+                    contest.Diamond = participation.Collected;
+                }
+                break;
+        }
     }
 
     private static string MedalName(this ContestMedal medal) => medal switch {


### PR DESCRIPTION
This enabled much faster queries for medal brackets.

Uses the following SQL to update existing contests

```sql
WITH brackets AS (
    SELECT 
        "JacobContestId" AS contest_id,
        MIN("Collected") filter (where "MedalEarned" = 5) AS diamond,
        MIN("Collected") filter (where "MedalEarned" = 4) AS platinum,
        MIN("Collected") filter (where "MedalEarned" = 3) AS gold,
        MIN("Collected") filter (where "MedalEarned" = 2) AS silver,
        MIN("Collected") filter (where "MedalEarned" = 1) AS bronze
    FROM "ContestParticipations"
    WHERE "MedalEarned" > 0
    GROUP BY "JacobContestId"
)
UPDATE "JacobContests"
SET 
    "Bronze" = COALESCE(bronze, 0),
    "Silver" = COALESCE(silver, 0),
    "Gold" = COALESCE(gold, 0),
    "Platinum" = COALESCE(platinum, 0),
    "Diamond" = COALESCE(diamond, 0)
FROM brackets
WHERE contest_id = "Id";
```