### PR TITLE
Remove RabbitMQ and use Redis pub/sub instead

### DIFF
--- a/EliteAPI/Configuration/Settings/MessagingSettings.cs
+++ b/EliteAPI/Configuration/Settings/MessagingSettings.cs
@@ -1,13 +1,10 @@
 ﻿namespace EliteAPI.Configuration.Settings;
 
-public class RabbitMqSettings {
-	public string Host { get; set; } = "localhost";
-	public string User { get; set; } = "user";
-	public string Password { get; set; } = string.Empty;
-	public int Port { get; set; } = 5672;
+public class MessagingSettings {
 	public string? ErrorAlertServer { get; set; }
 	public string? ErrorAlertChannel { get; set; }
 	public string? ErrorAlertPing { get; set; }
 	public string? WipeServer { get; set; }
 	public string? WipeChannel { get; set; }
+	public string ChannelName { get; set; } = "eliteapi_messages";
 }

--- a/EliteAPI/EliteAPI.csproj
+++ b/EliteAPI/EliteAPI.csproj
@@ -42,7 +42,6 @@
 		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
 		<PackageReference Include="Quartz.Extensions.Hosting" Version="3.13.1" />
-		<PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
 		<PackageReference Include="Riok.Mapperly" Version="4.1.1" ExcludeAssets="runtime" PrivateAssets="all" />
 		<PackageReference Include="Scalar.AspNetCore" Version="2.0.12" />
 		<PackageReference Include="StackExchange.Redis" Version="2.8.24" />

--- a/EliteAPI/Utilities/ServiceExtensions.cs
+++ b/EliteAPI/Utilities/ServiceExtensions.cs
@@ -173,7 +173,7 @@ public static class ServiceExtensions
         builder.Services.Configure<ConfigLeaderboardSettings>(builder.Configuration.GetSection("LeaderboardSettings"));
         builder.Services.Configure<FarmingItemsSettings>(builder.Configuration.GetSection("Farming"));
         builder.Services.Configure<ChocolateFactorySettings>(builder.Configuration.GetSection("ChocolateFactory"));
-        builder.Services.Configure<RabbitMqSettings>(builder.Configuration.GetSection("RabbitMq"));
+        builder.Services.Configure<MessagingSettings>(builder.Configuration.GetSection("Messaging"));
         builder.Services.Configure<ConfigEventSettings>(builder.Configuration.GetSection("Events"));
 
         builder.Services.Configure<ConfigApiRateLimitSettings>(

--- a/EliteAPI/appsettings.json
+++ b/EliteAPI/appsettings.json
@@ -11,10 +11,7 @@
   "ConnectionStrings": {
       "Postgres": "Server=localhost;Port=5436;Database=eliteapi;Username=user;Password=postgres123"
   },
-  "RabbitMq": {
-    "Host": "localhost",
-    "User": "user",
-    "Password": "rabbitPassword123",
+  "Messaging": {
     "ErrorAlertServer": "discord-guild-id",
     "ErrorAlertChannel": "discord-channel-id",
     "ErrorAlertPing": "discord-role-id",

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,7 +1,7 @@
 services:
   eliteapi:
     environment:
-      - ASPNETCORE_ENVIRONMENT={$ASPNETCORE_ENVIRONMENT:-Development}
+      - ASPNETCORE_ENVIRONMENT={$ASPNETCORE_ENVIRONMENT:-Production}
       - ASPNETCORE_URLS=http://+:7008;http://+:9102
     ports:
       - "7008"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,19 +75,6 @@ services:
         - prometheus-data:/data
     networks:
         - eliteapi-network
-  rabbit:
-    image: rabbitmq:3.8-alpine
-    restart: unless-stopped
-    env_file:
-      - .env
-    ports:
-        - '5672:5672'
-        - '15672:15672'
-    expose:
-        - '5672'
-        - '15672'
-    networks:
-        - eliteapi-network
         
 networks:
     eliteapi-network:


### PR DESCRIPTION
Removes RabbitMQ in favor of simply using redis/pub sub. Since this only communicates one way to the Bot, dropping the extra service makes sense.