### PR TITLE
Store/provide Minecraft player faces

### DIFF
--- a/EliteAPI/Data/Migrations/20250630020119_AddMinecraftAccountFace.Designer.cs
+++ b/EliteAPI/Data/Migrations/20250630020119_AddMinecraftAccountFace.Designer.cs
@@ -13,6 +13,7 @@ using EliteAPI.Models.Entities.Monetization;
 using HypixelAPI.DTOs;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -21,9 +22,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EliteAPI.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20250630020119_AddMinecraftAccountFace")]
+    partial class AddMinecraftAccountFace
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EliteAPI/Data/Migrations/20250630020119_AddMinecraftAccountFace.cs
+++ b/EliteAPI/Data/Migrations/20250630020119_AddMinecraftAccountFace.cs
@@ -1,0 +1,61 @@
+﻿using System.Collections.Generic;
+using EliteAPI.Models.Entities.Accounts;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EliteAPI.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMinecraftAccountFace : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Properties",
+                table: "MinecraftAccounts");
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "Face",
+                table: "MinecraftAccounts",
+                type: "bytea",
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "Hat",
+                table: "MinecraftAccounts",
+                type: "bytea",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TextureId",
+                table: "MinecraftAccounts",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Face",
+                table: "MinecraftAccounts");
+
+            migrationBuilder.DropColumn(
+                name: "Hat",
+                table: "MinecraftAccounts");
+
+            migrationBuilder.DropColumn(
+                name: "TextureId",
+                table: "MinecraftAccounts");
+
+            migrationBuilder.AddColumn<List<MinecraftAccountProperty>>(
+                name: "Properties",
+                table: "MinecraftAccounts",
+                type: "jsonb",
+                nullable: false);
+        }
+    }
+}

--- a/EliteAPI/EliteAPI.csproj
+++ b/EliteAPI/EliteAPI.csproj
@@ -46,6 +46,7 @@
 		  <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Scalar.AspNetCore" Version="2.5.3" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
 		<PackageReference Include="StackExchange.Redis" Version="2.8.24" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="7.2.0" />

--- a/EliteAPI/Features/Account/GetAccountFace/Endpoint.cs
+++ b/EliteAPI/Features/Account/GetAccountFace/Endpoint.cs
@@ -16,6 +16,9 @@ internal sealed class GetAccountFaceEndpoint(
 		Get("/account/{Player}/face", "/account/{Player}/face.png");
 		AllowAnonymous();
 		Version(0);
+		
+		// 4 hour cache
+		ResponseCache(4 * 60 * 60);
 
 		Summary(s => {
 			s.Summary = "Get Minecraft Account Face Image";

--- a/EliteAPI/Features/Account/GetAccountFace/Endpoint.cs
+++ b/EliteAPI/Features/Account/GetAccountFace/Endpoint.cs
@@ -1,0 +1,61 @@
+using System.Net.Mime;
+using EliteAPI.Models.Common;
+using EliteAPI.Services.Interfaces;
+using FastEndpoints;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace EliteAPI.Features.Account.GetAccountFace;
+
+internal sealed class GetAccountFaceEndpoint(
+	IMojangService mojangService
+) : Endpoint<PlayerRequest> {
+	
+	public override void Configure() {
+		Get("/account/{Player}/face", "/account/{Player}/face.png");
+		AllowAnonymous();
+		Version(0);
+
+		Summary(s => {
+			s.Summary = "Get Minecraft Account Face Image";
+			s.Description = "Returns an 8x8 or 72x72 face png image of the Minecraft account associated with the provided player name or UUID. 72x72 response includes the player's \"hat\" overlay. If not found, returns Steve's face.";
+		});
+	}
+
+	private static readonly byte[] SteveBase64 =
+		Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAA0klEQVR42k2OvwsBcRjGn+G9O7+PgSw2VgtikB+D0SR1+QcYlfJHKDv/gEUGkzLpFlkki2I0K8f9cO6K+35Leertffo8z1sv5dKxDzyFRMK/9LeLlzek6RbkkJ+DX+nfkyQK6FVLSCbioEAYrvmEZTvQtDum6g7Ub5Qhy1He/oVMjHUrRRAz7fEMrcoISuHAL1fnGhbqEPNBx/vBA8woBWCzP/FrVmSMZWSYJnTHwHp7RDaV4YXJfIlmPY+H4YBI+uD2dGC/3jheL3xLPpGHkaCALzxDWxVDfFzPAAAAAElFTkSuQmCC");
+
+	public override async Task HandleAsync(PlayerRequest request, CancellationToken c) {
+		var (face, hat) = await mojangService.GetMinecraftAccountFace(request.Player);
+		face ??= SteveBase64;
+		
+		if (hat is null) {
+			await SendBytesAsync(face, contentType: MediaTypeNames.Image.Png, cancellation: c);
+			return;
+		}
+		
+		using var faceImage = Image.Load(face);
+		
+		using var largeFace = faceImage.Clone(ctx => ctx.Resize(64, 64, KnownResamplers.NearestNeighbor));
+		using var finalImage = new Image<Rgba32>(72, 72);
+		
+		// ReSharper disable once AccessToDisposedClosure
+		finalImage.Mutate(ctx => ctx.DrawImage(largeFace, new Point(4, 4), 1f));
+		
+		// Resize the 8x8 hat to 72x72.
+		using var hatImage = Image.Load(hat);
+		using var largeHat = hatImage.Clone(ctx => ctx.Resize(72, 72, KnownResamplers.NearestNeighbor));
+		
+		// Draw the hat on top of the face image.
+		// ReSharper disable once AccessToDisposedClosure
+		finalImage.Mutate(ctx => ctx.DrawImage(largeHat, new Point(0, 0), 1f));
+
+		// Step 6: Convert the final composite image to a PNG byte array to be sent.
+		using var outputStream = new MemoryStream();
+		await finalImage.SaveAsPngAsync(outputStream, c); // Pass the cancellation token
+		var finalBytes = outputStream.ToArray();
+		
+		await SendBytesAsync(finalBytes, contentType: MediaTypeNames.Image.Png, cancellation: c);
+	}
+}

--- a/EliteAPI/Mappers/Accounts/AccountMapper.cs
+++ b/EliteAPI/Mappers/Accounts/AccountMapper.cs
@@ -23,14 +23,14 @@ public class MinecraftAccountMapper : Profile
         CreateMap<MinecraftAccount, MinecraftAccountDto>()
             .ForMember(a => a.FormattedName, opt => opt.MapFrom(a => a.EliteAccount != null ? a.EliteAccount.GetFormattedIgn() : a.Name))
             .ForMember(a => a.PrimaryAccount, opt => opt.MapFrom(a => a.Selected))
-            .ForMember(a => a.Properties, opt => opt.MapFrom(a => a.Properties))
+            .ForMember(a => a.Skin, opt => opt.MapFrom(a => a.Skin))
             .ForMember(a => a.Badges, opt => opt.MapFrom(a => a.Badges))
             .ForMember(a => a.Id, opt => opt.MapFrom(a => a.Id.ToString()));
 
         CreateMap<MinecraftAccount, MinecraftAccountDetailsDto>()
             .ForMember(a => a.PrimaryAccount, opt => opt.MapFrom(a => a.Selected))
             .ForMember(a => a.Badges, opt => opt.MapFrom(a => a.Badges))
-            .ForMember(a => a.Properties, opt => opt.MapFrom(a => a.Properties));
+            .ForMember(a => a.Skin, opt => opt.MapFrom(a => a.Skin));
     }
 }
 

--- a/EliteAPI/Models/DTOs/Outgoing/Accounts.cs
+++ b/EliteAPI/Models/DTOs/Outgoing/Accounts.cs
@@ -56,7 +56,7 @@ public class MinecraftAccountDetailsDto
     public required string Name { get; set; }
     public bool PrimaryAccount { get; set; } = true;
     public List<UserBadgeDto> Badges { get; set; } = new();
-    public List<MinecraftAccountPropertyDto> Properties { get; set; } = new();
+    public MinecraftSkinDto Skin { get; set; } = new();
 }
 
 [SwaggerSchema(Required = ["Id", "Name", "FormattedName", "Properties", "Profiles", "PrimaryAccount", "EventEntries"])]
@@ -71,8 +71,7 @@ public class MinecraftAccountDto
     public string? DiscordUsername { get; set; }
     public string? DiscordAvatar { get; set; }
     public UserSettingsDto Settings { get; set; } = new();
-
-    public List<MinecraftAccountPropertyDto> Properties { get; set; } = new();
+    public MinecraftSkinDto Skin { get; set; } = new();
     public List<ProfileDetailsDto> Profiles { get; set; } = new();
     public List<UserBadgeDto> Badges { get; set; } = new();
     public PlayerDataDto? PlayerData { get; set; }
@@ -83,6 +82,25 @@ public class MinecraftAccountPropertyDto
 {
     public required string Name { get; set; }
     public required string Value { get; set; }
+}
+
+public class MinecraftSkinDto
+{
+    /// <summary>
+    /// Minecraft skin texture ID
+    /// </summary>
+    public string? Texture { get; set; }
+    
+    /// <summary>
+    /// Base64 data image of the 8x8 face
+    /// </summary>
+    public string? Face { get; set; }
+    
+    /// <summary>
+    /// Base64 data image of the 8x8 hat (overlay on the face)
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Hat { get; set; }
 }
 
 

--- a/EliteAPI/Models/DTOs/Outgoing/Profiles.cs
+++ b/EliteAPI/Models/DTOs/Outgoing/Profiles.cs
@@ -33,9 +33,6 @@ public class MemberDetailsDto
     
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public MemberCosmeticsDto? Meta { get; set; }
-    
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public MinecraftSkinDto? Skin { get; set; }
 }
 
 public class ProfileMemberDto

--- a/EliteAPI/Models/DTOs/Outgoing/Profiles.cs
+++ b/EliteAPI/Models/DTOs/Outgoing/Profiles.cs
@@ -33,6 +33,9 @@ public class MemberDetailsDto
     
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public MemberCosmeticsDto? Meta { get; set; }
+    
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public MinecraftSkinDto? Skin { get; set; }
 }
 
 public class ProfileMemberDto

--- a/EliteAPI/Models/Entities/Accounts/MinecraftAccount.cs
+++ b/EliteAPI/Models/Entities/Accounts/MinecraftAccount.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using EliteAPI.Models.DTOs.Outgoing;
 using EliteAPI.Models.Entities.Hypixel;
 using Microsoft.EntityFrameworkCore;
 
@@ -19,9 +20,23 @@ public class MinecraftAccount
     public bool Selected { get; set; }
     
     public PlayerData? PlayerData { get; set; }
-
-    [Column(TypeName = "jsonb")]
-    public List<MinecraftAccountProperty> Properties { get; set; } = new();
+    
+    [MaxLength(128)]
+    public string? TextureId { get; set; }
+    
+    [Column(TypeName = "bytea")]
+    public byte[]? Face { get; set; }
+    [Column(TypeName = "bytea")]
+    public byte[]? Hat { get; set; }
+    
+    public string? FaceUrl => Face != null ? $"data:image/png;base64,{Convert.ToBase64String(Face)}" : null;
+    public string? HatUrl => Hat != null ? $"data:image/png;base64,{Convert.ToBase64String(Hat)}" : null;
+    public MinecraftSkinDto Skin => new MinecraftSkinDto
+    {
+        Face = FaceUrl,
+        Hat = HatUrl,
+        Texture = TextureId
+    };
     
     public AccountFlag Flags { get; set; } = AccountFlag.None;
     public bool IsBanned => Flags.HasFlag(AccountFlag.Banned);

--- a/EliteAPI/Services/Interfaces/IMojangService.cs
+++ b/EliteAPI/Services/Interfaces/IMojangService.cs
@@ -12,4 +12,6 @@ public interface IMojangService
     Task<MinecraftAccount?> FetchMinecraftAccountByUuid(string uuid);
     Task<MinecraftAccount?> GetMinecraftAccountByIgn(string ign);
     Task<MinecraftAccount?> GetMinecraftAccountByUuidOrIgn(string uuidOrIgn);
+    
+    Task<(byte[]? face, byte[]? hat)> GetMinecraftAccountFace(string uuidOrIgn);
 }


### PR DESCRIPTION
- No longer store/provide minecraft player "properties" property
  - Was a decent chunk of data not being used by anything
- Parse and fetch a player's skin to store the face and overlay
- Provide face/overlay in account response
- Adds a `/account/{ignOrUuid}/face` endpoint to get face image