### PR TITLE
Add ability to save missing fortune to your profile

### DIFF
--- a/EliteAPI/Configuration/Farming.json
+++ b/EliteAPI/Configuration/Farming.json
@@ -73,6 +73,20 @@
       "SQUASH_RING": -1,
       "CROPIE_TALISMAN": -1,
       "POWER_RELIC": -1
-    }
+    },
+    "ShardIds": [
+      "SHARD_WARTYBUG",
+      "SHARD_DRAGONFLY",
+      "SHARD_FIREFLY",
+      "SHARD_LUNAR_MOTH",
+      "SHARD_LADYBUG",
+      "SHARD_CROPEETLE",
+      "SHARD_INVISIBUG",
+      "SHARD_TERMITE",
+      "SHARD_PRAYING_MANTIS",
+      "SHARD_PEST",
+      "SHARD_MUDWORM",
+      "SHARD_GALAXY_FISH"
+    ]
   }
 }

--- a/EliteAPI/Configuration/Settings/FarmingItemsSettings.cs
+++ b/EliteAPI/Configuration/Settings/FarmingItemsSettings.cs
@@ -11,4 +11,5 @@ public class FarmingItemsSettings {
     public Dictionary<string, short> FarmingEquipmentIds { get; set; } = new();
     public Dictionary<string, short> FarmingArmorIds { get; set; } = new();
     public Dictionary<string, short> FarmingAccessoryIds { get; set; } = new();
+    public List<string> ShardIds { get; set; } = [];
 }

--- a/EliteAPI/Data/Migrations/20250722235302_AddFortuneSettings.Designer.cs
+++ b/EliteAPI/Data/Migrations/20250722235302_AddFortuneSettings.Designer.cs
@@ -14,6 +14,7 @@ using EliteAPI.Models.Entities.Monetization;
 using HypixelAPI.DTOs;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -22,9 +23,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EliteAPI.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20250722235302_AddFortuneSettings")]
+    partial class AddFortuneSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EliteAPI/Data/Migrations/20250722235302_AddFortuneSettings.cs
+++ b/EliteAPI/Data/Migrations/20250722235302_AddFortuneSettings.cs
@@ -1,0 +1,59 @@
+﻿using EliteAPI.Features.Account.DTOs;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EliteAPI.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFortuneSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<FortuneSettingsDto>(
+                name: "Fortune",
+                table: "UserSettings",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "NameStyleId",
+                table: "UserSettings",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserSettings_NameStyleId",
+                table: "UserSettings",
+                column: "NameStyleId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserSettings_Cosmetics_NameStyleId",
+                table: "UserSettings",
+                column: "NameStyleId",
+                principalTable: "Cosmetics",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_UserSettings_Cosmetics_NameStyleId",
+                table: "UserSettings");
+
+            migrationBuilder.DropIndex(
+                name: "IX_UserSettings_NameStyleId",
+                table: "UserSettings");
+
+            migrationBuilder.DropColumn(
+                name: "Fortune",
+                table: "UserSettings");
+
+            migrationBuilder.DropColumn(
+                name: "NameStyleId",
+                table: "UserSettings");
+        }
+    }
+}

--- a/EliteAPI/EliteAPI.csproj
+++ b/EliteAPI/EliteAPI.csproj
@@ -58,7 +58,6 @@
 	<ItemGroup>
 		<Folder Include="Data\Grafana\Datasources\" />
 		<Folder Include="Data\Grafana\Dashboards\" />
-		<Folder Include="Features\Account\Endpoints\" />
 		<Folder Include="Features\Auth\Endpoints\" />
 		<Folder Include="Features\Events\Admin\Members\" />
 		<Folder Include="Features\Profiles\Models\" />

--- a/EliteAPI/Features/Account/DTOs/Accounts.cs
+++ b/EliteAPI/Features/Account/DTOs/Accounts.cs
@@ -141,6 +141,19 @@ public class UserSettingsDto
     /// 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public WeightStyleLinkedDto? LeaderboardStyle { get; set; }
+    
+    /// <summary>
+    /// Selected name style for the user
+    /// </summary>
+    /// 
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public WeightStyleLinkedDto? NameStyle { get; set; }
+    
+    /// <summary>
+    /// Fortune settings for the user
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public FortuneSettingsDto? Fortune { get; set; }
 }
 
 public class UpdateUserSettingsDto

--- a/EliteAPI/Features/Account/DTOs/FortuneSettingsDto.cs
+++ b/EliteAPI/Features/Account/DTOs/FortuneSettingsDto.cs
@@ -1,0 +1,29 @@
+namespace EliteAPI.Features.Account.DTOs;
+
+public class FortuneSettingsDto
+{
+	/// <summary>
+	/// Member fortune settings for each minecraft account, then each profile.
+	/// </summary>
+    public Dictionary<string, Dictionary<string, MemberFortuneSettingsDto>> Accounts { get; set; } = new();
+}
+
+public class MemberFortuneSettingsDto
+{
+	/// <summary>
+	/// Amount of strength used for mooshroom fortune
+	/// </summary>
+	public int Strength { get; set; } = 0;
+	/// <summary>
+	/// Community center farming fortune level
+	/// </summary>
+	public int CommunityCenter { get; set; } = 0;
+	/// <summary>
+	/// Attribute shards
+	/// </summary>
+	public Dictionary<string, int> Attributes { get; set; } = new();
+	/// <summary>
+	/// Exported crops
+	/// </summary>
+	public Dictionary<string, bool> Exported { get; set; } = new();
+}

--- a/EliteAPI/Features/Account/Endpoints/UpdateFortuneSettings/Endpoint.cs
+++ b/EliteAPI/Features/Account/Endpoints/UpdateFortuneSettings/Endpoint.cs
@@ -1,0 +1,43 @@
+using EliteAPI.Features.Account.DTOs;
+using EliteAPI.Features.Account.Services;
+using EliteAPI.Models.Common;
+using EliteAPI.Utilities;
+using ErrorOr;
+using FastEndpoints;
+
+namespace EliteAPI.Features.Account.UpdateFortuneSettings;
+
+internal sealed class UpdateFortuneSettingsEndpoint(
+	IAccountService accountService
+) : Endpoint<UpdateFortuneSettings, ErrorOr<Success>> {
+	
+	public override void Configure() {
+		Post("/account/{PlayerUuid}/{ProfileUuid}/fortune");
+		Version(0);
+
+		Summary(s => {
+			s.Summary = "Update Fortune Settings for Account";
+		});
+	}
+
+	public override async Task<ErrorOr<Success>> ExecuteAsync(UpdateFortuneSettings request, CancellationToken c) {
+		var id = User.GetDiscordId();
+		if (id is null)
+		{
+			return Error.Unauthorized();
+		}
+        
+		return await accountService.UpdateFortuneSettings(id.Value, request.PlayerUuidFormatted, request.ProfileUuidFormatted, request.Settings);
+	}
+}
+
+internal sealed class UpdateFortuneSettings : PlayerProfileUuidRequest {
+	[FromBody] 
+	public required MemberFortuneSettingsDto Settings { get; set; }
+}
+
+internal sealed class UpdateFortuneSettingsValidator : Validator<UpdateFortuneSettings> {
+	public UpdateFortuneSettingsValidator() {
+		Include(new PlayerProfileUuidRequestValidator());	
+	}
+}

--- a/EliteAPI/Features/Account/Models/UserSettings.cs
+++ b/EliteAPI/Features/Account/Models/UserSettings.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using EliteAPI.Features.Account.DTOs;
 using EliteAPI.Features.Leaderboards.Models;
 using EliteAPI.Models.Entities.Monetization;
 
@@ -29,6 +30,16 @@ public class UserSettings {
 	[ForeignKey(nameof(LeaderboardStyle))]
 	public int? LeaderboardStyleId { get; set; }
 	public WeightStyle? LeaderboardStyle { get; set; }
+		
+	[ForeignKey(nameof(NameStyle))]
+	public int? NameStyleId { get; set; }
+	public WeightStyle? NameStyle { get; set; }
+	
+	/// <summary>
+	/// Custom fortune settings for the user.
+	/// </summary>
+	[Column(TypeName = "jsonb")]
+	public FortuneSettingsDto? Fortune { get; set; }
 	
 	/// <summary>
 	/// Leaderboard custom cosmetics.

--- a/EliteAPI/Features/Account/Services/IAccountService.cs
+++ b/EliteAPI/Features/Account/Services/IAccountService.cs
@@ -1,5 +1,6 @@
 ﻿using EliteAPI.Features.Account.DTOs;
 using EliteAPI.Features.Account.Models;
+using ErrorOr;
 using Microsoft.AspNetCore.Mvc;
 
 namespace EliteAPI.Features.Account.Services;
@@ -18,5 +19,6 @@ public interface IAccountService
     Task<ActionResult> LinkAccount(ulong discordId, string playerUuidOrIgn);
     Task<ActionResult> UnlinkAccount(ulong discordId, string playerUuidOrIgn);
     Task<ActionResult> MakePrimaryAccount(ulong discordId, string playerUuidOrIgn);
-    Task<ActionResult> UpdateSettings(ulong discordId, UpdateUserSettingsDto settings);
+    Task<ErrorOr<Success>> UpdateSettings(ulong discordId, UpdateUserSettingsDto settings);
+    Task<ErrorOr<Success>> UpdateFortuneSettings(ulong discordId, string playerUuid, string profileUuid, MemberFortuneSettingsDto settings);
 }

--- a/EliteAPI/Mappers/Accounts/AccountMapper.cs
+++ b/EliteAPI/Mappers/Accounts/AccountMapper.cs
@@ -50,7 +50,9 @@ public class EliteMapper : Profile
     {
         CreateMap<UserSettings, UserSettingsDto>()
             .ForMember(a => a.WeightStyle, opt => opt.MapFrom(a => a.WeightStyle))
-            .ForMember(a => a.LeaderboardStyle, opt => opt.MapFrom(a => a.LeaderboardStyle));
+            .ForMember(a => a.LeaderboardStyle, opt => opt.MapFrom(a => a.LeaderboardStyle))
+            .ForMember(a => a.NameStyle, opt => opt.MapFrom(a => a.NameStyle))
+            .ForMember(a => a.Fortune, opt => opt.MapFrom(a => a.Fortune));
 
         CreateMap<Entitlement, EntitlementDto>()
             .ForMember(a => a.Id, opt => opt.MapFrom(a => a.Id.ToString()))


### PR DESCRIPTION
Adds a `fortune` property to `UserSettings` that's a simple store for fortune settings that aren't in the API.

Right now, this just consists of:
- Strength
- Community Center Upgrade
- Exported Crops
- Attribute Shards